### PR TITLE
Blocks employer from admin view at admin login

### DIFF
--- a/code/transit-fe/src/app/city-go-admin/city-go-admin.component.ts
+++ b/code/transit-fe/src/app/city-go-admin/city-go-admin.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { EmployerService } from './shared/employer.service';
+import { Router } from "@angular/router";
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'city-go-admin',
@@ -8,10 +10,11 @@ import { EmployerService } from './shared/employer.service';
 })
 export class CityGoAdminComponent implements OnInit {
 
-  constructor(private employerService: EmployerService) {
-    
+  constructor(private employerService: EmployerService,private router: Router,private auth: AuthService) {
+    if(auth.userProfile$.source['_value']['https://any-namespace/roles'] != 'admin'){
+      this.router.navigate(['employer']);
+    }
   }
-
   ngOnInit() {
     this.employerService.initEmployers();
   }


### PR DESCRIPTION
Simple fix to prevent employer from viewing admin page when logging into admin login. Redirects to employer view